### PR TITLE
Quickstart do Projeto - Consegue ler identificadores

### DIFF
--- a/main.jjl
+++ b/main.jjl
@@ -1,0 +1,3 @@
+identificadorValido outroValido e OutroValido
+_identificadorValido
+id3nt1f1c4d0rV4l1d0

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.compiler</groupId>
+    <artifactId>lexical-analyzer</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/src/main/java/com/compiler/Main.java
+++ b/src/main/java/com/compiler/Main.java
@@ -1,0 +1,7 @@
+package com.compiler;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Quickstart");
+    }
+}

--- a/src/main/java/com/compiler/Main.java
+++ b/src/main/java/com/compiler/Main.java
@@ -1,7 +1,34 @@
 package com.compiler;
 
+import com.compiler.lexical.Scanner;
+import com.compiler.lexical.token.Token;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 public class Main {
-    public static void main(String[] args) {
-        System.out.println("Quickstart");
+    public static void main(String[] args) throws IOException {
+
+        System.out.println("""
+                Grupo compostor por:
+                - João Pedro Soares Figueiredo
+                - João Victor Nunes
+                - Luiz Filipe de Matos Ramos
+                """);
+
+        List<Token> tokens = new ArrayList<>();
+
+        Scanner scanner = new Scanner("main.jjl");
+        Token token;
+
+        do {
+            token = scanner.nextToken();
+            if (token != null) {
+                tokens.add(token);
+            }
+        } while (token != null);
+
+        tokens.forEach(System.out::println);
     }
 }

--- a/src/main/java/com/compiler/lexical/Scanner.java
+++ b/src/main/java/com/compiler/lexical/Scanner.java
@@ -1,0 +1,80 @@
+package com.compiler.lexical;
+
+import com.compiler.lexical.exception.LexicalErrorException;
+import com.compiler.lexical.token.Token;
+import com.compiler.lexical.token.TokenType;
+import com.compiler.lexical.utils.CharUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class Scanner {
+
+    private final char[] sourceCode;
+    private int position;
+    private int line;
+    private int column;
+
+    public Scanner(String filename) throws IOException {
+        String content = Files.readString(Paths.get(filename));
+        this.sourceCode = content.toCharArray();
+        this.position = 0;
+        this.line = 1;
+        this.column = 1;
+    }
+
+    public Token nextToken() throws LexicalErrorException {
+        ignoreWhiteSpaces();
+
+        if (isEoF()) {
+            return null;
+        }
+
+        char current = peekChar();
+
+        if (Character.isLetter(current) || CharUtils.isUnderLine(current)) {
+            return readIdentifier();
+        }
+
+        throw new LexicalErrorException("Token inesperado: '" + nextChar() + "' na linha " + this.line + " coluna " + this.column);
+    }
+
+    private Token readIdentifier() {
+        StringBuilder content = new StringBuilder();
+        int startLine = this.line;
+        int startColumn = this.column;
+
+        do {
+            content.append(nextChar());
+        } while (!isEoF() && (CharUtils.isLetter(peekChar()) || CharUtils.isDigit(peekChar()) || CharUtils.isUnderLine(peekChar())));
+
+        return new Token(TokenType.IDENTIFIER, content.toString(), startLine, startColumn);
+    }
+
+    private void ignoreWhiteSpaces() {
+        while (!isEoF() && CharUtils.isWhitespace(peekChar())) {
+            nextChar();
+        }
+    }
+
+    private char nextChar() {
+        char c = this.sourceCode[this.position++];
+        if (CharUtils.isLineBreak(c)) {
+            this.line++;
+            this.column = 1;
+        } else {
+            this.column++;
+        }
+        return c;
+    }
+
+    private char peekChar() {
+        if (isEoF()) return '\0';
+        return sourceCode[position];
+    }
+
+    private boolean isEoF() {
+        return position >= this.sourceCode.length;
+    }
+}

--- a/src/main/java/com/compiler/lexical/exception/LexicalErrorException.java
+++ b/src/main/java/com/compiler/lexical/exception/LexicalErrorException.java
@@ -1,0 +1,7 @@
+package com.compiler.lexical.exception;
+
+public class LexicalErrorException extends RuntimeException {
+    public LexicalErrorException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/compiler/lexical/token/Token.java
+++ b/src/main/java/com/compiler/lexical/token/Token.java
@@ -1,0 +1,58 @@
+package com.compiler.lexical.token;
+
+public class Token {
+
+    private TokenType type;
+    private String content;
+    private int startColumn;
+    private int line;
+
+    public Token(TokenType type, String content, int line, int startColumn) {
+        this.type = type;
+        this.content = content;
+        this.line = line;
+        this.startColumn = startColumn;
+    }
+
+    public TokenType getType() {
+        return type;
+    }
+
+    public void setType(TokenType type) {
+        this.type = type;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public int getStartColumn() {
+        return startColumn;
+    }
+
+    public void setStartColumn(int startColumn) {
+        this.startColumn = startColumn;
+    }
+
+    public int getLine() {
+        return line;
+    }
+
+    public void setLine(int line) {
+        this.line = line;
+    }
+
+    @Override
+    public String toString() {
+        return "Token {\n" +
+                "  type: " + type + ",\n" +
+                "  content: '" + content + "',\n" +
+                "  line: " + line + ",\n" +
+                "  column: " + startColumn + "\n" +
+                "}";
+    }
+}

--- a/src/main/java/com/compiler/lexical/token/TokenType.java
+++ b/src/main/java/com/compiler/lexical/token/TokenType.java
@@ -1,0 +1,5 @@
+package com.compiler.lexical.token;
+
+public enum TokenType {
+    IDENTIFIER
+}

--- a/src/main/java/com/compiler/lexical/utils/CharUtils.java
+++ b/src/main/java/com/compiler/lexical/utils/CharUtils.java
@@ -1,0 +1,24 @@
+package com.compiler.lexical.utils;
+
+public class CharUtils {
+
+    public static boolean isLetter(char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    }
+
+    public static boolean isUnderLine(char c) {
+        return c == '_';
+    }
+
+    public static boolean isDigit(char c) {
+        return (c >= '0' && c <= '9');
+    }
+
+    public static boolean isWhitespace(char c) {
+        return isLineBreak(c) || c == ' ' || c == '\t' || c == '\r';
+    }
+
+    public static boolean isLineBreak(char c) {
+        return c == '\n';
+    }
+}


### PR DESCRIPTION
### Impacto
Este PR adiciona a lógica de ler tokens, lendo apenas identificadores (ignora todos os espaços em branco)

Já está sendo implementado com a lógica de estourar erro mostrando erro de token inválido na linha x coluna y.

### Evidências
Identificadores válidos:
<img width="1883" height="1044" alt="image" src="https://github.com/user-attachments/assets/c1c41c46-0d10-4dfb-9e65-d04365e8bf08" />

chars inválidos:
<img width="1914" height="1047" alt="image" src="https://github.com/user-attachments/assets/6ff3e00e-905e-4f76-9fe7-8ac803f4e29a" />
