### PR TITLE
Add suporte ao operador de atribuição (=)

### DIFF
--- a/main.jjl
+++ b/main.jjl
@@ -1,6 +1,1 @@
-identificadorValido outroValido e OutroValido
-_identificadorValido
-id3nt1f1c4d0rV4l1d0
-resultado + valor1
-varA + varB - varC
-varD / varE * varF
+= 0

--- a/src/main/java/com/compiler/lexical/Scanner.java
+++ b/src/main/java/com/compiler/lexical/Scanner.java
@@ -9,8 +9,6 @@ import com.compiler.lexical.utils.CharUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.Map;
 
 public class Scanner {
 
@@ -41,7 +39,6 @@ public class Scanner {
         }
 
         TokenType tokenType = TokenDefinitions.getTokenType(current);
-
         if (tokenType != null) {
             String content = String.valueOf(current);
             nextChar();

--- a/src/main/java/com/compiler/lexical/token/TokenDefinitions.java
+++ b/src/main/java/com/compiler/lexical/token/TokenDefinitions.java
@@ -13,6 +13,7 @@ public final class TokenDefinitions {
         SINGLE_CHAR_TOKENS.put('-', TokenType.MINUS);
         SINGLE_CHAR_TOKENS.put('*', TokenType.TIMES);
         SINGLE_CHAR_TOKENS.put('/', TokenType.DIVIDE);
+        SINGLE_CHAR_TOKENS.put('=', TokenType.ASSIGN);
     }
 
     private TokenDefinitions() {}

--- a/src/main/java/com/compiler/lexical/token/TokenType.java
+++ b/src/main/java/com/compiler/lexical/token/TokenType.java
@@ -5,5 +5,6 @@ public enum TokenType {
     PLUS,
     MINUS,
     TIMES,
-    DIVIDE
+    DIVIDE,
+    ASSIGN,
 }


### PR DESCRIPTION
**Descrição:**  
Este PR implementa o ponto 3 do Checkpoint 01 do projeto **Construção de Compiladores I**, adicionando suporte ao operador de atribuição (`=`) no analisador léxico.

![Imagem do operador de atribuição](https://github.com/user-attachments/assets/af5068d4-2346-4451-9f72-26ba7be9316c)