### PR TITLE
Feat/reserved words

### DIFF
--- a/main.jjl
+++ b/main.jjl
@@ -1,0 +1,7 @@
+int
+float
+print
+if
+else
+x
+myVar

--- a/src/main/java/com/compiler/lexical/Scanner.java
+++ b/src/main/java/com/compiler/lexical/Scanner.java
@@ -1,6 +1,7 @@
 package com.compiler.lexical;
 
 import com.compiler.lexical.exception.LexicalErrorException;
+import com.compiler.lexical.token.ReservedWords;
 import com.compiler.lexical.token.Token;
 import com.compiler.lexical.token.TokenType;
 import com.compiler.lexical.token.TokenDefinitions;
@@ -129,7 +130,14 @@ public class Scanner {
         } while (!isEoF() && (CharUtils.isLetter(peekChar()) || CharUtils.isDigit(peekChar())
                 || CharUtils.isUnderLine(peekChar())));
 
-        return new Token(TokenType.IDENTIFIER, content.toString(), startLine, startColumn);
+        String word = content.toString();
+        TokenType reservedType = ReservedWords.getTokenType(word);
+
+        if (reservedType != null) {
+            return new Token(reservedType, word, startLine, startColumn);
+        }
+
+        return new Token(TokenType.IDENTIFIER, word, startLine, startColumn);
     }
 
     private void ignoreWhiteSpaces() {

--- a/src/main/java/com/compiler/lexical/token/ReservedWords.java
+++ b/src/main/java/com/compiler/lexical/token/ReservedWords.java
@@ -1,0 +1,23 @@
+package com.compiler.lexical.token;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class ReservedWords {
+
+    private static final Map<String, TokenType> RESERVED_WORDS = new HashMap<>();
+
+    static {
+        RESERVED_WORDS.put("int", TokenType.INT);
+        RESERVED_WORDS.put("float", TokenType.FLOAT);
+        RESERVED_WORDS.put("print", TokenType.PRINT);
+        RESERVED_WORDS.put("if", TokenType.IF);
+        RESERVED_WORDS.put("else", TokenType.ELSE);
+    }
+
+    private ReservedWords() {}
+
+    public static TokenType getTokenType(String word) {
+        return RESERVED_WORDS.get(word);
+    }
+}

--- a/src/main/java/com/compiler/lexical/token/TokenType.java
+++ b/src/main/java/com/compiler/lexical/token/TokenType.java
@@ -16,5 +16,10 @@ public enum TokenType {
     LEFT_PAREN,
     RIGHT_PAREN,
     NUMBER,
-    COMMA
+    COMMA,
+    INT,
+    FLOAT,
+    PRINT,
+    IF,
+    ELSE
 }


### PR DESCRIPTION
# Adição de suporte para palavras reservadas no analisador léxico

Este PR implementa o reconhecimento das seguintes palavras reservadas:

- `int`
- `float`
- `print`
- `if`
- `else`

## Alterações realizadas

- Criada uma tabela de palavras reservadas no analisador léxico.
- Modificado o método `readIdentifier()` para verificar se o identificador lido é uma palavra reservada.
- Retornado o token correspondente caso seja uma palavra reservada.
- Identificadores que não são palavras reservadas continuam sendo do tipo `IDENTIFIER`.

## Testes realizados

- Arquivo de teste com palavras reservadas e outros identificadores.
- Verificado que palavras reservadas retornam o token correto.
- Verificado que outros identificadores continuam como `IDENTIFIER`.

## Resultado esperado

```text
Token { type=INT, content='int', line=1, column=1 }
Token { type=FLOAT, content='float', line=2, column=1 }
Token { type=PRINT, content='print', line=3, column=1 }
Token { type=IF, content='if', line=4, column=1 }
Token { type=ELSE, content='else', line=5, column=1 }
Token { type=IDENTIFIER, content='x', line=6, column=1 }
Token { type=IDENTIFIER, content='myVar', line=7, column=1 }
```

# Resultado obtido:
<img width="442" height="802" alt="image" src="https://github.com/user-attachments/assets/deee049b-5a3e-412e-b256-0b3d724e4a83" />
