### PR TITLE
Corrige erro de aceitar número com 3 pontos em 2 tokens diferentes

### DIFF
--- a/src/main/java/com/compiler/lexical/Scanner.java
+++ b/src/main/java/com/compiler/lexical/Scanner.java
@@ -188,7 +188,7 @@ public class Scanner {
             content.append(nextChar());
 
             if (!CharUtils.isDigit(peekChar())) {
-                throw new LexicalErrorException("Número inválido na linha " + line + " coluna " + column);
+                throw new LexicalErrorException("Número inválido: caractere inesperado '" + peekChar() + "' na linha " + line + " coluna " + column);
             }
 
             while (CharUtils.isDigit(peekChar())) {
@@ -196,9 +196,14 @@ public class Scanner {
             }
         }
 
-        if (!hasDigitsBeforeDot && !hasDot) {
-            throw new LexicalErrorException("Número inválido na linha " + line + " coluna " + column);
+        if (peekChar() == '.') {
+            throw new LexicalErrorException("Número inválido: múltiplos pontos detectados, caractere '" + peekChar() + "' na linha " + line + " coluna " + column);
         }
+
+        if (!hasDigitsBeforeDot && !hasDot) {
+            throw new LexicalErrorException("Número inválido: caractere inesperado '" + peekChar() + "' na linha " + line + " coluna " + column);
+        }
+
         return new Token(TokenType.NUMBER, content.toString(), startLine, startColumn);
     }
 


### PR DESCRIPTION
### Impacto
Com o input 1.0.4, é lido dois tokens: "1.0" e ".4". O que é um comportamento inesperado. Com isso, este PR corrige para que 1.0.4 não seja aceito, além de melhorar as mensagens de erro, mostrando o caracter q aconteceu a treta.